### PR TITLE
Check for unique MAC address to avoid binding error on interface aliases

### DIFF
--- a/lib/NetworkInterface.js
+++ b/lib/NetworkInterface.js
@@ -238,8 +238,12 @@ NetworkInterface.prototype._bindSocket = function () {
       if (_this2._multicastAddr) socket.setMulticastInterface(_this2._multicastAddr);
 
       // add membership on each unique IPv4 interface address
+      let unique_mac = [];
       var addresses = (_ref = []).concat.apply(_ref, _toConsumableArray(Object.values(os.networkInterfaces()))).filter(function (addr) {
-        return addr.family === 'IPv4';
+        if (!unique_mac.includes(addr.mac)) {
+          unique_mac.push(addr.mac);
+          return addr.family === 'IPv4';
+        }
       }).map(function (addr) {
         return addr.address;
       });


### PR DESCRIPTION
This is due to the listening can only be setup once per interface and not on an interface alias.
The following errors occur as it tries to bind to the same interface.
The above fix checks for a unique MAC address to avoid this.

```May 20 12:42:43 boatnet signalk-server[12947]: OUCH! - could not add membership to interface 192.168.3.15 Error: addMembership EADDRINUSE
May 20 12:42:43 boatnet signalk-server[12947]:     at Socket.addMembership (node:dgram:861:11)
May 20 12:42:43 boatnet signalk-server[12947]:     at /usr/lib/node_modules/signalk-server/node_modules/dnssd2/lib/NetworkInterface.js:249:18
May 20 12:42:43 boatnet signalk-server[12947]:     at Array.forEach (<anonymous>)
May 20 12:42:43 boatnet signalk-server[12947]:     at Socket.<anonymous> (/usr/lib/node_modules/signalk-server/node_modules/dnssd2/lib/NetworkInterface.js:247:57)
May 20 12:42:43 boatnet signalk-server[12947]:     at Socket.emit (node:events:517:28)
May 20 12:42:43 boatnet signalk-server[12947]:     at startListening (node:dgram:183:10)
May 20 12:42:43 boatnet signalk-server[12947]:     at node:dgram:371:7
May 20 12:42:43 boatnet signalk-server[12947]:     at process.processTicksAndRejections (node:internal/process/task_queues:83:21) {
May 20 12:42:43 boatnet signalk-server[12947]:   errno: -98,
May 20 12:42:43 boatnet signalk-server[12947]:   code: 'EADDRINUSE',
May 20 12:42:43 boatnet signalk-server[12947]:   syscall: 'addMembership'
May 20 12:42:43 boatnet signalk-server[12947]: }
May 20 12:42:43 boatnet signalk-server[12947]: OUCH! - could not add membership to interface 192.168.3.16 Error: addMembership EADDRINUSE
May 20 12:42:43 boatnet signalk-server[12947]:     at Socket.addMembership (node:dgram:861:11)
May 20 12:42:43 boatnet signalk-server[12947]:     at /usr/lib/node_modules/signalk-server/node_modules/dnssd2/lib/NetworkInterface.js:249:18
May 20 12:42:43 boatnet signalk-server[12947]:     at Array.forEach (<anonymous>)
May 20 12:42:43 boatnet signalk-server[12947]:     at Socket.<anonymous> (/usr/lib/node_modules/signalk-server/node_modules/dnssd2/lib/NetworkInterface.js:247:57)
May 20 12:42:43 boatnet signalk-server[12947]:     at Socket.emit (node:events:517:28)
May 20 12:42:43 boatnet signalk-server[12947]:     at startListening (node:dgram:183:10)
May 20 12:42:43 boatnet signalk-server[12947]:     at node:dgram:371:7
May 20 12:42:43 boatnet signalk-server[12947]:     at process.processTicksAndRejections (node:internal/process/task_queues:83:21) {
May 20 12:42:43 boatnet signalk-server[12947]:   errno: -98,
May 20 12:42:43 boatnet signalk-server[12947]:   code: 'EADDRINUSE',
May 20 12:42:43 boatnet signalk-server[12947]:   syscall: 'addMembership'
May 20 12:42:43 boatnet signalk-server[12947]: }
```
